### PR TITLE
Tensors can now be scaled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ cuttResult cuttDestroy(cuttHandle handle);
 // handle            = Returned handle to cuTT plan
 // idata             = Input data size product(dim)
 // odata             = Output data size product(dim)
+// alpha             = scaling-factor for input
+// beta              = scaling-factor for output
 // 
 // Returns
 // Success/unsuccess code

--- a/src/cutt.cpp
+++ b/src/cutt.cpp
@@ -184,7 +184,7 @@ cuttResult cuttPlan(cuttHandle* handle, int rank, int* dim, int* permutation, si
 }
 
 cuttResult cuttPlanMeasure(cuttHandle* handle, int rank, int* dim, int* permutation, size_t sizeofType,
-  cudaStream_t stream, void* idata, void* odata) {
+  cudaStream_t stream, void* idata, void* odata, void* alpha, void *beta) {
 
   // Check that input parameters are valid
   cuttResult inpCheck = cuttPlanCheckInput(rank, dim, permutation, sizeofType);
@@ -245,7 +245,7 @@ cuttResult cuttPlanMeasure(cuttHandle* handle, int rank, int* dim, int* permutat
     cudaCheck(cudaDeviceSynchronize());
     timer.start();
     // Execute plan
-    if (!cuttKernel(*it, idata, odata)) return CUTT_INTERNAL_ERROR;
+    if (!cuttKernel(*it, idata, odata, alpha, beta)) return CUTT_INTERNAL_ERROR;
     timer.stop();
     double curTime = timer.seconds();
     // it->print();
@@ -293,7 +293,7 @@ cuttResult cuttDestroy(cuttHandle handle) {
   return CUTT_SUCCESS;
 }
 
-cuttResult cuttExecute(cuttHandle handle, void* idata, void* odata) {
+cuttResult cuttExecute(cuttHandle handle, void* idata, void* odata, void* alpha, void* beta) {
   auto it = planStorage.find(handle);
   if (it == planStorage.end()) return CUTT_INVALID_PLAN;
 
@@ -305,6 +305,6 @@ cuttResult cuttExecute(cuttHandle handle, void* idata, void* odata) {
   cudaCheck(cudaGetDevice(&deviceID));
   if (deviceID != plan.deviceID) return CUTT_INVALID_DEVICE;
 
-  if (!cuttKernel(plan, idata, odata)) return CUTT_INTERNAL_ERROR;
+  if (!cuttKernel(plan, idata, odata, alpha, beta)) return CUTT_INTERNAL_ERROR;
   return CUTT_SUCCESS;
 }

--- a/src/cutt.h
+++ b/src/cutt.h
@@ -74,7 +74,7 @@ cuttResult cuttPlan(cuttHandle* handle, int rank, int* dim, int* permutation, si
 // Success/unsuccess code
 // 
 cuttResult cuttPlanMeasure(cuttHandle* handle, int rank, int* dim, int* permutation, size_t sizeofType,
-  cudaStream_t stream, void* idata, void* odata);
+  cudaStream_t stream, void* idata, void* odata, void* alpha = NULL, void* beta = NULL);
 
 //
 // Destroy plan
@@ -88,16 +88,18 @@ cuttResult cuttPlanMeasure(cuttHandle* handle, int rank, int* dim, int* permutat
 cuttResult cuttDestroy(cuttHandle handle);
 
 //
-// Execute plan out-of-place
+// Execute plan out-of-place; performs a tensor transposition of the form \f[ \mathcal{B}_{\pi(i_0,i_1,...,i_{d-1})} \gets \alpha * \mathcal{A}_{i_0,i_1,...,i_{d-1}} + \beta * \mathcal{B}_{\pi(i_0,i_1,...,i_{d-1})}, \f]
 //
 // Parameters
 // handle            = Returned handle to cuTT plan
 // idata             = Input data size product(dim)
 // odata             = Output data size product(dim)
+// alpha             = scalar for input
+// beta              = scalar for output
 // 
 // Returns
 // Success/unsuccess code
 //
-cuttResult cuttExecute(cuttHandle handle, void* idata, void* odata);
+cuttResult cuttExecute(cuttHandle handle, void* idata, void* odata, void* alpha = NULL, void* beta = NULL);
 
 #endif // CUTT_H

--- a/src/cuttkernel.h
+++ b/src/cuttkernel.h
@@ -31,6 +31,6 @@ void cuttKernelSetSharedMemConfig();
 int cuttKernelLaunchConfiguration(const int sizeofType, const TensorSplit& ts,
 	const int deviceID, const cudaDeviceProp& prop, LaunchConfig& lc);
 
-bool cuttKernel(cuttPlan_t& plan, void* dataIn, void* dataOut);
+bool cuttKernel(cuttPlan_t& plan, void* dataIn, void* dataOut, void* alpha, void* beta);
 
 #endif // CUTTKERNEL_H


### PR DESCRIPTION
cuTT now supports tensor transpositions of the form:
     B_\perm(i0, i1, ...) = alpha * A_{i0,i1,...} + beta * B_\perm(i0,i1,...)
with alpha and beta being scalars.

TODO: support for alpha and beta in the case of a simple copy (i.e., perm = identity) is still missing